### PR TITLE
Fix: Update GitHub Actions to use npm install instead of npm ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
             exit 0
           elif [ -f "${{ github.workspace }}/package.json" ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=npx --yes" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine package manager"
@@ -48,7 +48,6 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ${{ env.BUILD_PATH }}/package-lock.json
 
       - name: Setup Pages
         id: pages


### PR DESCRIPTION
Fixes the deployment workflow failure caused by missing package-lock.json

Changes:
- npm ci → npm install (works without lock file)
- npx --no-install → npx --yes (allows package installation)
- Removed cache-dependency-path (no lock file exists)

This resolves the error: "Some specified paths were not resolved, unable to cache dependencies"

https://claude.ai/code/session_01SjzuU5ZakuECN1jB1i4ivA