### PR TITLE
Add CI tests to workflow and improve reusability

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main, master]
+  pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:
@@ -21,7 +23,18 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.check-deploy.outputs.should_deploy }}
     steps:
+      - name: Check if should deploy
+        id: check-deploy
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/heads/master" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -58,6 +71,10 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
         working-directory: ${{ env.BUILD_PATH }}
 
+      - name: Run type checking
+        run: ${{ steps.detect-package-manager.outputs.runner }} astro check
+        working-directory: ${{ env.BUILD_PATH }}
+
       - name: Build with Astro
         run: |
           ${{ steps.detect-package-manager.outputs.runner }} astro build \
@@ -69,6 +86,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.BUILD_PATH }}/dist
+        if: steps.check-deploy.outputs.should_deploy == 'true'
 
   deploy:
     environment:
@@ -77,6 +95,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     name: Deploy
+    if: needs.build.outputs.should_deploy == 'true'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- Adds CI testing on pull requests to validate changes before merging
- Improves workflow reusability with conditional deployment logic
- Ensures builds are tested on PRs without triggering deployment

## Changes
- Add `pull_request` trigger to run workflow on PRs targeting main/master
- Add type checking step (`astro check`) that runs on all events
- Implement conditional deployment using job outputs
- Build step now runs on both PRs and pushes to validate before merge
- Deploy step only runs on push to main/master branch

## Test plan
- [x] Create this PR to verify workflow runs on pull requests
- [x] Verify type checking and build steps execute successfully
- [x] Confirm deploy step is skipped on PR (should only run on push to master)
- [ ] After merge, confirm deployment still works on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)